### PR TITLE
Fix Markdown Syntax Highlighting

### DIFF
--- a/themes/one-hunter.json
+++ b/themes/one-hunter.json
@@ -163,6 +163,21 @@
             "font_style": null,
             "font_weight": null
           },
+          "constructor": {
+            "color": "#E1239A",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#E1239A",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#E1239A",
+            "font_style": null,
+            "font_weight": 700
+          },
           "function": {
             "color": "#0488DB",
             "font_style": null,
@@ -173,8 +188,23 @@
             "font_style": null,
             "font_weight": null
           },
+          "link_text": {
+            "color": "#0488DB",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#E1239A",
+            "font_style": null,
+            "font_weight": null
+          },
           "number": {
             "color": "#FF7E00",
+            "font_style": null,
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#0BA463",
             "font_style": null,
             "font_weight": null
           },
@@ -199,12 +229,12 @@
             "font_weight": null
           },
           "punctuation.list_marker": {
-            "color": "#5D5D5D",
+            "color": "#FF7E00",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
-            "color": "#5D5D5D",
+            "color": "#E1239A",
             "font_style": null,
             "font_weight": null
           },
@@ -234,9 +264,14 @@
             "font_weight": null
           },
           "text.literal": {
-            "color": "#0BA463",
+            "color": "#689FDE",
             "font_style": null,
             "font_weight": null
+          },
+          "title": {
+            "color": "#0488DB",
+            "font_style": null,
+            "font_weight": 700
           },
           "type": {
             "color": "#FF7E00",
@@ -416,6 +451,21 @@
             "font_style": null,
             "font_weight": null
           },
+          "constructor": {
+            "color": "#F4457D",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#F4457D",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#F4457D",
+            "font_style": null,
+            "font_weight": 700
+          },
           "function": {
             "color": "#43AAF9",
             "font_style": null,
@@ -426,6 +476,16 @@
             "font_style": null,
             "font_weight": 700
           },
+          "link_text": {
+            "color": "#53A1FA",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#F4457D",
+            "font_style": null,
+            "font_weight": null
+          },
           "number": {
             "color": "#F9C35A",
             "font_style": null,
@@ -433,6 +493,11 @@
           },
           "operator": {
             "color": "#EFEFEF",
+            "font_style": null,
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#5BD1B9",
             "font_style": null,
             "font_weight": null
           },
@@ -452,12 +517,12 @@
             "font_weight": null
           },
           "punctuation.list_marker": {
-            "color": "#EFEFEF",
+            "color": "#F9C35A",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
-            "color": "#EFEFEF",
+            "color": "#F4457D",
             "font_style": null,
             "font_weight": null
           },
@@ -487,9 +552,14 @@
             "font_weight": null
           },
           "text.literal": {
-            "color": "#5BD1B9",
+            "color": "#9FBDE0",
             "font_style": null,
             "font_weight": null
+          },
+          "title": {
+            "color": "#53A1FA",
+            "font_style": null,
+            "font_weight": 700
           },
           "type": {
             "color": "#F9C35A",
@@ -664,6 +734,16 @@
             "font_style": null,
             "font_weight": null
           },
+          "emphasis": {
+            "color": "#24837B",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#AD8301",
+            "font_style": null,
+            "font_weight": 700
+          },
           "function": {
             "color": "#205EA6",
             "font_style": null,
@@ -720,12 +800,12 @@
             "font_weight": null
           },
           "punctuation.list_marker": {
-            "color": "#100F0F",
+            "color": "#AD8301",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
-            "color": "#100F0F",
+            "color": "#A02F6F",
             "font_style": null,
             "font_weight": null
           },
@@ -763,6 +843,11 @@
             "color": "#24837B",
             "font_style": null,
             "font_weight": null
+          },
+          "title": {
+            "color": "#AD8301",
+            "font_style": null,
+            "font_weight": 700
           },
           "type": {
             "color": "#AD8301",
@@ -937,6 +1022,16 @@
             "font_style": null,
             "font_weight": null
           },
+          "emphasis": {
+            "color": "#3AA99F",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#D0A215",
+            "font_style": null,
+            "font_weight": 700
+          },
           "function": {
             "color": "#4385BE",
             "font_style": null,
@@ -993,12 +1088,12 @@
             "font_weight": null
           },
           "punctuation.list_marker": {
-            "color": "#CECDC3",
+            "color": "#D0A215",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
-            "color": "#CECDC3",
+            "color": "#CE5D97",
             "font_style": null,
             "font_weight": null
           },
@@ -1036,6 +1131,11 @@
             "color": "#3AA99F",
             "font_style": null,
             "font_weight": null
+          },
+          "title": {
+            "color": "#D0A215",
+            "font_style": null,
+            "font_weight": 700
           },
           "type": {
             "color": "#D0A215",
@@ -1210,6 +1310,16 @@
             "font_style": null,
             "font_weight": null
           },
+          "emphasis": {
+            "color": "#4fc3f7",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#f7bc62",
+            "font_style": null,
+            "font_weight": 700
+          },
           "function": {
             "color": "#4fc3f7",
             "font_style": null,
@@ -1266,12 +1376,12 @@
             "font_weight": null
           },
           "punctuation.list_marker": {
-            "color": "#E3E1E1",
+            "color": "#f7bc62",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
-            "color": "#E3E1E1",
+            "color": "#f06292",
             "font_style": null,
             "font_weight": null
           },
@@ -1309,6 +1419,11 @@
             "color": "#66dfc4",
             "font_style": null,
             "font_weight": null
+          },
+          "title": {
+            "color": "#f7bc62",
+            "font_style": null,
+            "font_weight": 700
           },
           "type": {
             "color": "#f7bc62",
@@ -1488,6 +1603,21 @@
             "font_style": null,
             "font_weight": null
           },
+          "constructor": {
+            "color": "#DD4F7D",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#DD4F7D",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#DD4F7D",
+            "font_style": null,
+            "font_weight": 700
+          },
           "function": {
             "color": "#43AAF9",
             "font_style": null,
@@ -1498,6 +1628,16 @@
             "font_style": null,
             "font_weight": 700
           },
+          "link_text": {
+            "color": "#43AAF9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#DD4F7D",
+            "font_style": null,
+            "font_weight": null
+          },
           "number": {
             "color": "#FAC760",
             "font_style": null,
@@ -1505,6 +1645,11 @@
           },
           "operator": {
             "color": "#EFEFEF",
+            "font_style": null,
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#5BD1B9",
             "font_style": null,
             "font_weight": null
           },
@@ -1529,12 +1674,12 @@
             "font_weight": null
           },
           "punctuation.list_marker": {
-            "color": "#EFEFEF",
+            "color": "#FAC760",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
-            "color": "#EFEFEF",
+            "color": "#DD4F7D",
             "font_style": null,
             "font_weight": null
           },
@@ -1564,7 +1709,7 @@
             "font_weight": null
           },
           "text.literal": {
-            "color": "#5BD1B9",
+            "color": "#9FBDE0",
             "font_style": null,
             "font_weight": null
           },
@@ -1572,6 +1717,11 @@
             "color": "#43AAF9",
             "font_style": null,
             "font_weight": null
+          },
+          "title": {
+            "color": "#43AAF9",
+            "font_style": null,
+            "font_weight": 700
           },
           "type": {
             "color": "#DD4F7D",


### PR DESCRIPTION
Closes #4 

# Corrected in Zed

<img width="2488" height="2240" alt="CleanShot 2025-11-19 at 11 48 07" src="https://github.com/user-attachments/assets/0fc8ce42-e2f5-496c-9f86-1fb4380d5181" />

## Original Incorrect in Zed

<img width="2488" height="2240" alt="CleanShot 2025-11-19 at 11 37 56 2" src="https://github.com/user-attachments/assets/176b9c53-30c5-43b1-995d-4a497f181f9b" />
